### PR TITLE
Add reference analysis and apply google style docstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Then download the ACL Anthology github repository:
 **Examples Running `get_paper.py`**
 
 Get random papers to annotate:
-* 1: `python get_paper.py --years 18-19 --confs "P,N,D"  --n_sample 2 --template template.cpt --feature fulltext`
+* 1: `python get_paper.py --years 18-19 --confs "P,N,D" --n_sample 2 --template template.cpt --feature fulltext`
  
 Get a specific paper to annotate:
 * 2: `python get_paper.py --paper_id P19-1032 --template template.cpt --feature fulltext`
@@ -59,7 +59,7 @@ where:
 * `n_sample`: the number of sampled papers if paper_id is not specified
 * `template`: the file of concept template (e.g. template.cpt)
 * `feature`: which part of paper is used to classify (e.g. fulltext or title)
-* `n_ref`: number of reference papers used to analyze tags
+* `use_cite`: whether to use citation papers (c.f. `paper_id` should be specified to use citation papers)
 
 ## Generating Aggregate Statistics/Charts
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ where:
 * `n_sample`: the number of sampled papers if paper_id is not specified
 * `template`: the file of concept template (e.g. template.cpt)
 * `feature`: which part of paper is used to classify (e.g. fulltext or title)
+* `n_ref`: number of reference papers used to analyze tags
 
 ## Generating Aggregate Statistics/Charts
 

--- a/get_paper.py
+++ b/get_paper.py
@@ -8,18 +8,23 @@ import urllib.request
 import bs4 as bs
 import time
 
+from utils import get_references, label_references
 
 
-
-def label_paper(paper_id = None, paper_meta = None, cased_regexes = None, feature = None):
+def label_paper(paper_id=None, paper_meta=None, cased_regexes=None, feature=None, n_ref=0):
   """Label one paper
 
-  :param paper_id: The paper ID
-  :param paper_meta: Store meta information of a paper
-  :param cased_regexes: store meta information of a paper
-  :param feature: which part of content will we used to label papers. i.e. "title" or "fulltext"
-  :return: Nothing.
+  Args:
+    paper_id (str): The paper ID
+    paper_meta (bs4.element.Tag): Store meta information of a paper
+    cased_regexes (list): Regex information used to paper labeling
+    feature (str): which part of content will we use to label papers (e.g. "title" or "fulltext")
+    n_ref (int): number of reference papers used to analyze
+  
+  Returns:
+    None
   """
+
   if not os.path.isfile(f'papers/{paper_id}.pdf'):
     os.makedirs(f'papers/', exist_ok=True)
     try:
@@ -32,36 +37,54 @@ def label_paper(paper_id = None, paper_meta = None, cased_regexes = None, featur
 
   with open(f'papers/{paper_id}.txt', 'r') as f:
     paper_text = '\n'.join(f.readlines())
-  paper_title = ''.join(paper_meta.title.findAll(text=True))
+  paper_title = paper_meta.title.text
 
-  is_cased = 1 # if case-sensitive
+  is_cased = True # if case-sensitive
   if feature == "title":
-    feature = paper_title
-    is_cased = 0
+    contents = paper_title
+    is_cased = False
   elif feature == "fulltext":
-    feature = paper_text
-    is_cased = 1
+    contents = paper_text
+    is_cased = True
 
-  predicted_tags = paper_classifier.classify(feature, cased_regexes, is_cased)
+  predicted_tags = paper_classifier.classify(contents, cased_regexes, is_cased)
+
+  reference_tags = dict()
+  if (n_ref > 0) and paper_meta.doi:  # if analyze reference papers
+    paper_doi = paper_meta.doi.text.lower()
+    refs = get_references(paper_doi, n_ref)
+
+    if not refs:
+      print(f'WARNING: Cannot fetch reference paper information of {paper_id}')
+    else:
+      reference_tags = dict(label_references(refs, feature, cased_regexes, is_cased))
+  
+  # Display result
   print(f'Title: {paper_title}\n'
         f'Local location: papers/{paper_id}.pdf\n'
         f'Online location: https://www.aclweb.org/anthology/{paper_id}.pdf\n'
         f'Text file location: auto/{paper_id}.txt')
   for i, tag in enumerate(predicted_tags):
-    print(f'Tag {i}: {tag}')
+    print(f'Tag {i+1}: {tag}')
   print("------------------------------------------------\n")
-
+  
+  # Store result
   os.makedirs(f'auto/', exist_ok=True)
-  fin = open(f'auto/{paper_id}.txt', 'w')
-  print(f'# Title: {paper_title}\n# Online location: https://www.aclweb.org/anthology/{paper_id}.pdf', file=fin)
-  for tag, conf, just in predicted_tags:
-    print(f'# CHECK: confidence={conf}, justification={just}\n{tag}',file=fin)
-
-
+  with open(f'auto/{paper_id}.txt', 'w') as f:
+    print(f'# Title: {paper_title}\n# Online location: https://www.aclweb.org/anthology/{paper_id}.pdf', file=f)
+    for tag, conf, just in predicted_tags:
+      if tag in reference_tags:
+        just += f', {reference_tags[tag]} occurrences in the refs'
+        del reference_tags[tag]
+      print(f'# CHECK: confidence = {conf}, justification = {just}\n{tag}',file=f)
+    print("------------------------------------------------", file=f)
+    
+    if reference_tags:  # if there are more tags in the reference
+      for elem in reference_tags:
+        print(f'# CHECK: justification = {reference_tags[elem]} occurrences in the reference papers\n{elem}',file=f)
 
 
 if __name__ == "__main__":
-
   parser = argparse.ArgumentParser(description="Get a paper to try to read and annotate")
 
   parser.add_argument("--paper_id", type=str, default=None,
@@ -70,34 +93,35 @@ if __name__ == "__main__":
                       help="If a paper ID is not specified, a year (e.g. 19) or range of years (e.g. 99-02) from which"+
                            " to select a random paper.")
   parser.add_argument("--confs", type=str, default="P,N,D",
-                      help="A comma-separted list of conference abbreviations from which papers can be selected")
+                      help="A comma-separated list of conference abbreviations from which papers can be selected")
   parser.add_argument("--volumes", type=str, default="1,2",
                       help="A comma-separated list of volumes to include (default is long and short research papers)."+
                            " 'all' for no filtering.")
   parser.add_argument("--n_sample", type=str, default="1",
                       help="the number of sampled papers if paper_id is not specified (e.g. 1)."
                            " Write 'all' to select all papers from those years/conferences/volumes.")
-
   parser.add_argument("--template", type=str, default="template.cpt",
                       help="The file of concept template (e.g. template.cpt)")
-
   parser.add_argument("--feature", type=str, default="fulltext",
                       help="Which parts of paper is used to classify (e.g. fulltext|title)")
+  parser.add_argument("--n_ref", type=int, default=0,
+                      help="The number of reference papers used to look up")
 
   args = parser.parse_args()
 
   # init variables
-  feature = args.feature
-  paper_id = args.paper_id
-  template = args.template
-  n_sample = args.n_sample
-  volumes = args.volumes.split(',')
+  feature   = args.feature
+  paper_id  = args.paper_id
+  template  = args.template
+  n_sample  = args.n_sample
+  volumes   = args.volumes.split(',')
+  n_ref     = args.n_ref
   paper_map = {}
 
-  # lead the concept template
-  cased_regexes = paper_classifier.genConceptReg(file_concept=template, formate_col = 3)
+  # read the concept template
+  cased_regexes = paper_classifier.generate_concept_regex(file_concept=template, format_col=3)
 
-  # if paper_id has not been specified
+  # if 'paper_id' is not specified
   if paper_id == None:
     years = args.years.split('-')
     confs = args.confs.split(',')
@@ -107,7 +131,7 @@ if __name__ == "__main__":
       assert len(years) == 1, "invalid format of years, {args.years}"
     for pref, year in itertools.product(confs, years):
       year = int(year)
-      pref= pref.upper()
+      pref = pref.upper()
       with open(f'acl-anthology/data/xml/{pref}{year:02d}.xml', 'r') as f:
         soup = bs.BeautifulSoup(f, 'xml')
       for vol in soup.collection.find_all('volume'):
@@ -120,37 +144,34 @@ if __name__ == "__main__":
     if n_sample == 'all':
       for paper_id in paper_keys:
         paper_meta = paper_map[paper_id]
-        label_paper(paper_id, paper_meta, cased_regexes, feature)
+        label_paper(paper_id, paper_meta, cased_regexes, feature, n_ref)
     else:
       for _ in range(int(n_sample)):
         randid = random.choice(paper_keys)
         if not os.path.isfile(f'annotations/{randid}.txt') and not os.path.isfile(f'auto/{randid}.txt'):
           paper_id = randid
           paper_meta = paper_map[paper_id]
-          #print(paper_meta)
-          label_paper(paper_id, paper_meta, cased_regexes, feature)
+          label_paper(paper_id, paper_meta, cased_regexes, feature, n_ref)
         else:
           print(f'Warning: {paper_id} has been labeled!')
 
-  # if paper_id is specified
+  # if 'paper_id' is specified
   else:
     prefix = paper_id.split("-")[0]
+    
     with open(f'acl-anthology/data/xml/{prefix}.xml', 'r') as f:
         soup = bs.BeautifulSoup(f, 'xml')
         for vol in soup.collection.find_all('volume'):
             if vol.attrs['id'] in volumes:
               for pap in vol.find_all('paper'):
-                if pap.url and pap.url.contents[0] == paper_id:
+                if (pap.url) and (pap.url.contents[0] == paper_id):
                   paper_map[pap.url.contents[0]] = pap
-                  #print(paper_map[pap.url.contents[0]])
                   if not os.path.isfile(f'annotations/{paper_id}.txt') and not os.path.isfile(f'auto/{paper_id}.txt'):
-                      label_paper(paper_id, paper_map[paper_id], cased_regexes, feature)
+                      label_paper(paper_id, paper_map[paper_id], cased_regexes, feature, n_ref)
                       sys.exit(1)
                   else:
                     print(f'Warning: {paper_id} has been labeled!')
 
     if len(paper_map) == 0:
-      print(f'Warning: {paper_id} can not been found!')
+      print(f'Warning: {paper_id} cannot be found!')
       sys.exit(1)
-
-

--- a/rule_classifier.py
+++ b/rule_classifier.py
@@ -2,35 +2,59 @@ import os
 import sys
 import re
 
-# generate regular expression from a concept template
-# the formate of template:
-# concept \t father_concept \t keywords
-def genConceptReg(file_concept="test.cpt", formate_col = 3):
-	if not os.path.exists(file_concept):
-		print("can not find concept template")
-		os._exit(0)
 
-	cased_regexes = []
-	fin = open(file_concept,"r")
-	for line in fin:
-		line = line.rstrip("\n")
-		if len(line.split("\t"))!= formate_col or line[0] == "#":
-			continue
-		info_list = line.split("\t")
-		cased_regexes.append((info_list[2].rstrip("\r"), info_list[0], 0.9))
-	fin.close()
-	return cased_regexes
+def generate_concept_regex(file_concept="test.cpt", format_col=3):
+  """Generate regular expressions using inputted concept file
+  
+  The template file should follow format below:
+ 	concept \t father_concept \t keywords
+
+  Args:
+    file_concept (str): File containing regular expressions
+    format_col (int): Number of columns in concept file
+  
+  Returns:
+    list: Generated regular expressions
+  """
+
+  if not os.path.exists(file_concept):
+    print("can not find concept template")
+    os._exit(0)
+
+  cased_regexes = []
+  with open(file_concept,"r") as f:
+    for line in f:
+      line = line.rstrip("\n")
+      if (len(line.split("\t")) != format_col) or (line[0] == "#"):
+        continue
+      info_list = line.split("\t")
+      cased_regexes.append((info_list[2].rstrip("\r"), info_list[0], 0.9))
+  
+  return cased_regexes
 
 
-def classify(paper_text=None, cased_regexes = None, flag_cased = 1, threshold=0.5):
-	ret = []
-	if paper_text != None:
-		for reg, tag, certainty in cased_regexes:
-			if flag_cased == 1:  
-				m = re.search(reg, paper_text)
-			else:
-				m = re.search(reg, paper_text,re.IGNORECASE)
+def classify(paper_text=None, cased_regexes=None, flag_cased=True, threshold=0.5):
+  """Classify input text and returns labeled tag list 
 
-			if m:
-				ret.append((tag, certainty, 'Matched regex {}'.format(str(reg))))
-	return ret
+  Args:
+    paper_text (str): Input text will be either 'full text' or just 'title'
+    cased_regexes (list): Generated regular expressions from concept file
+    flag_cased (bool): A Boolean value that indicates whether the case is case sensitive or not
+    threshold (float): [To Be Updated]
+  
+  Returns:
+    list: Labeled tag list
+  """
+
+  result = []
+  if paper_text != None:
+    for regex, tag, certainty in cased_regexes:
+      if flag_cased:
+        m = re.search(regex, paper_text)
+      else:
+        m = re.search(regex, paper_text, re.IGNORECASE)
+
+      if m:
+        result.append((tag, certainty, f'Matched regex {regex}'))
+  
+  return result

--- a/rule_classifier.py
+++ b/rule_classifier.py
@@ -22,7 +22,7 @@ def generate_concept_regex(file_concept="test.cpt", format_col=3):
     os._exit(0)
 
   cased_regexes = []
-  with open(file_concept,"r") as f:
+  with open(file_concept, "r") as f:
     for line in f:
       line = line.rstrip("\n")
       if (len(line.split("\t")) != format_col) or (line[0] == "#"):

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,74 @@
+import os
+import random
+import requests
+import collections
+import urllib.request
+
+import rule_classifier as paper_classifier
+
+
+def label_references(refs, feature, cased_regexes, is_cased):
+  """Label reference papers
+
+  Args:
+    ref (list): arixv ID list of reference papers
+    feature (str): which part of content will we use to label papers (e.g. "title" or "fulltext")
+    cased_regexes (list): regex information used to paper labeling    
+    is_cased (bool): boolean value that indicates whether the case is case sensitive or not
+  
+  Returns:
+    Counter: tag counter made by all the tags from refs
+  """
+
+  total_tags = []
+
+  for ref in refs:
+    paper_title, paper_id = ref
+    
+    if not os.path.isfile(f'papers/{paper_id}.pdf'):
+      try:
+        urllib.request.urlretrieve(f'https://arxiv.org/pdf/{paper_id}.pdf', f'papers/{paper_id}.pdf')
+        # time.sleep(1) # maybe we would wait some time until downloading processing finishes.
+        os.system(f'pdftotext papers/{paper_id}.pdf papers/{paper_id}.txt')
+      except:
+        print(f'WARNING: Error while downloading/processing https://arxiv.org/pdf/{paper_id}.pdf')
+        continue
+
+    with open(f'papers/{paper_id}.txt', 'r') as f:
+      paper_text = '\n'.join(f.readlines())
+
+    if feature == "title":
+      contents = paper_title
+    elif feature == "fulltext":
+      contents = paper_text
+
+    total_tags += paper_classifier.classify(contents, cased_regexes, is_cased)
+
+  total_tags = [tag[0] for tag in total_tags]
+
+  return collections.Counter(total_tags)
+
+
+def get_references(doi=None, n_ref=0):
+  """Get reference papers using Semantic Scholar API
+
+  Args:
+    doi (str): DOI of the paper
+    n_ref (int): number of reference papers used to analyze
+  
+  Returns:
+    list: arixv ID list of reference papers
+  """
+
+  semantic_scholar = f'https://api.semanticscholar.org/v1/paper/{doi}'
+  res = requests.get(semantic_scholar)
+  
+  if res.status_code != 200:
+    return False
+
+  citations = res.json()['references']
+  refs = [(c['title'], c['arxivId']) for c in citations if c['arxivId'] is not None]
+  n_ref = len(refs) if len(refs) < n_ref else n_ref
+  random.shuffle(refs)
+  
+  return refs[:n_ref]

--- a/utils.py
+++ b/utils.py
@@ -104,7 +104,7 @@ def get_citations(id=None, doi=None):
 
 
 def label_citation_papers(refs, tags, paper_id):
-  """Label papers which citated already "known" paper
+  """Label papers which cited already "known" paper
 
   Args:
     refs (list): DOI list of citation papers

--- a/utils.py
+++ b/utils.py
@@ -7,68 +7,129 @@ import urllib.request
 import rule_classifier as paper_classifier
 
 
-def label_references(refs, feature, cased_regexes, is_cased):
-  """Label reference papers
+def label_paper(paper_id=None, paper_meta=None, cased_regexes=None, feature=None, use_cite=False):
+  """Label one paper or citations papers
 
   Args:
-    ref (list): arixv ID list of reference papers
+    paper_id (str): The paper ID
+    paper_meta (bs4.element.Tag): Store meta information of a paper
+    cased_regexes (list): Regex information used to paper labeling
     feature (str): which part of content will we use to label papers (e.g. "title" or "fulltext")
-    cased_regexes (list): regex information used to paper labeling    
-    is_cased (bool): boolean value that indicates whether the case is case sensitive or not
+    use_cite (bool): whether to use known citation papers
   
   Returns:
-    Counter: tag counter made by all the tags from refs
+    None
   """
 
-  total_tags = []
-
-  for ref in refs:
-    paper_title, paper_id = ref
-    
-    if not os.path.isfile(f'papers/{paper_id}.pdf'):
+  if not use_cite:
+    if not os.path.exists(f'papers/{paper_id}.pdf'):
+      os.makedirs(f'papers/', exist_ok=True)
       try:
-        urllib.request.urlretrieve(f'https://arxiv.org/pdf/{paper_id}.pdf', f'papers/{paper_id}.pdf')
-        # time.sleep(1) # maybe we would wait some time until downloading processing finishes.
+        urllib.request.urlretrieve(f'https://www.aclweb.org/anthology/{paper_id}.pdf', f'papers/{paper_id}.pdf')
+        # time.sleep(2) # maybe we would wait some time until downloading processing finishes.
         os.system(f'pdftotext papers/{paper_id}.pdf papers/{paper_id}.txt')
       except:
-        print(f'WARNING: Error while downloading/processing https://arxiv.org/pdf/{paper_id}.pdf')
-        continue
+        print(f'WARNING: Error while downloading/processing https://www.aclweb.org/anthology/{paper_id}.pdf')
+        return
 
     with open(f'papers/{paper_id}.txt', 'r') as f:
       paper_text = '\n'.join(f.readlines())
+    paper_title = paper_meta.title.text
 
+    is_cased = True # if case-sensitive
     if feature == "title":
       contents = paper_title
+      is_cased = False
     elif feature == "fulltext":
       contents = paper_text
+      is_cased = True
 
-    total_tags += paper_classifier.classify(contents, cased_regexes, is_cased)
+    predicted_tags = paper_classifier.classify(contents, cased_regexes, is_cased)
+    
+    # Display result
+    print(f'Title: {paper_title}\n'
+          f'Local location: papers/{paper_id}.pdf\n'
+          f'Online location: https://www.aclweb.org/anthology/{paper_id}.pdf\n'
+          f'Text file location: auto/{paper_id}.txt')
+    for i, tag in enumerate(predicted_tags):
+      print(f'Tag {i+1}: {tag}')
+    print("------------------------------------------------\n")
+    
+    # Store result
+    os.makedirs(f'auto/', exist_ok=True)
+    with open(f'auto/{paper_id}.txt', 'w') as f:
+      print(f'# Title: {paper_title}\n# Online location: https://www.aclweb.org/anthology/{paper_id}.pdf', file=f)
+      for tag, conf, just in predicted_tags:
+        print(f'# CHECK: confidence = {conf}, justification = {just}\n{tag}',file=f)
 
-  total_tags = [tag[0] for tag in total_tags]
+  else:  # if use citation papers
+    if paper_meta.doi:
+      paper_doi = paper_meta.doi.text.lower()
+      refs, tags = get_citations(paper_id, paper_doi)
+      
+      if not refs:
+        print(f'WARNING: Cannot fetch {paper_id} citation related information')
+      else:
+        label_citation_papers(refs, tags, paper_id)
 
-  return collections.Counter(total_tags)
 
-
-def get_references(doi=None, n_ref=0):
-  """Get reference papers using Semantic Scholar API
+def get_citations(id=None, doi=None):
+  """Get citation papers using Semantic Scholar API
 
   Args:
-    doi (str): DOI of the paper
-    n_ref (int): number of reference papers used to analyze
+    id (str): paper ID
+    doi (str): paper DOI
   
   Returns:
-    list: arixv ID list of reference papers
+    list: citation papers' (doi, title) list of tuple
+    list: tag list from known paper
   """
 
   semantic_scholar = f'https://api.semanticscholar.org/v1/paper/{doi}'
   res = requests.get(semantic_scholar)
   
   if res.status_code != 200:
-    return False
+    return False, None
 
-  citations = res.json()['references']
-  refs = [(c['title'], c['arxivId']) for c in citations if c['arxivId'] is not None]
-  n_ref = len(refs) if len(refs) < n_ref else n_ref
-  random.shuffle(refs)
+  citations = res.json()['citations']
+  refs = [(c['doi'][c['doi'].rfind('/')+1:].upper(), c['title']) 
+          for c in citations if c['doi'] is not None]
+
+  # Read tag list from "known" labeled paper
+  with open(f'annotations/{id}.txt', 'r') as f:
+    tags = f.readlines()[2:]  # filter out title and location
+    tags = [tag.replace('\n', '') for tag in tags]
   
-  return refs[:n_ref]
+  return refs, tags
+
+
+def label_citation_papers(refs, tags, paper_id):
+  """Label papers which citated already "known" paper
+
+  Args:
+    refs (list): DOI list of citation papers
+    tags (list): tag list from "known" paper
+    paper_id (str): "known" paper id
+  
+  Returns:
+    None
+  """
+
+  justification = f'Found from reference paper {paper_id}'
+  possible_confs = ['P', 'N', 'D']
+  new_paps = collections.defaultdict(str)
+  
+  os.makedirs(f'auto/', exist_ok=True)
+  for ref in refs:
+    ref_id, ref_title = ref
+    if not os.path.exists(f'annotations/{ref_id}.txt') and not os.path.exists(f'auto/{ref_id}.txt'):
+      if ref_id[0] in possible_confs:
+        with open(f'auto/{ref_id}.txt', 'w') as f:
+          print(f'# Title: {ref_title}\n# Online location: https://www.aclweb.org/anthology/{ref_id}.pdf', file=f)
+          for tag in tags:
+            print(f'# CHECK: justification = {justification}\n{tag}',file=f)
+        new_paps[ref_id] = ref_title
+
+  print(f'Totally {len(new_paps)} new papers are labeled using {paper_id} tag information.')
+  for k, v in dict(new_paps).items():
+    print(f': [{k}] {v}')


### PR DESCRIPTION
Hi, 
I enjoyed your awesome project! Thx for hard work.
I read the issue(#2) you opened, and add naive `citation_analysis` logic using **Semantic Scholar API** (your recommendation).

It calls API using inputted paper's **DOI information** and gets referenced papers' addresses.
Then apply the `label_paper` logic to extract tag information from referenced papers.

After that, using `reference_tag`, we can flourish `justification` for the label recommendation :) 
The result would be like below:

```
# Title: Inducing Document Structure for Aspect-based Summarization
# Online location: https://www.aclweb.org/anthology/P19-1630.pdf
# CHECK: confidence = 0.9, justification = Matched regex multi-task learning
train-mtl
# CHECK: confidence = 0.9, justification = Matched regex Recurrent Neural Network|RNN|recurrent neural networks, 4 occurrences in the refs
arch-rnn
# CHECK: confidence = 0.9, justification = Matched regex Long Short-term Memory|LSTMs|LSTM, 4 occurrences in the refs
arch-lstm
# CHECK: confidence = 0.9, justification = Matched regex Convolutional Neural Networks|CNNs|convolutional neural network, 3 occurrences in the refs
arch-cnn
# CHECK: confidence = 0.9, justification = Matched regex attention, 4 occurrences in the refs
arch-att
# CHECK: confidence = 0.9, justification = Matched regex coverage, 2 occurrences in the refs
arch-coverage
...
```

Because of the limitations of API, sometimes we get **no** information about the referenced paper.
I think it will be future work. And multi-processing is also needed to accelerate pdf download logic :+1: 